### PR TITLE
Fixed unable to castle bug

### DIFF
--- a/src/script.user.js
+++ b/src/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
-// @name         Lichess Bot
-// @description  Fully automated lichess bot
-// @author       Nuro
+// @name         HyperBullet Lichess Bot
+// @description  Super fast bot
+// @author       NuroC, t0gepi
 // @match         *://lichess.org/*
 // @run-at        document-start
 // @grant         none
@@ -9,7 +9,7 @@
 // ==/UserScript==
 
 let chessEngine;
-let currentFen = "";
+let moves = [];
 let bestMove;
 let webSocketWrapper = null;
 
@@ -27,16 +27,18 @@ function interceptWebSocket() {
             wrappedWebSocket.addEventListener("message", function (event) {
                 let message = JSON.parse(event.data);
                 console.log(message)
-                if (message.d && typeof message.d.fen === "string" && typeof message.v === "number") {
-                    currentFen = message.d.fen;
-
-                    let isWhitesTurn = message.v % 2 == 0;
-                    if (isWhitesTurn) {
-                        currentFen += " w";
-                    } else {
-                        currentFen += " b";
+                if (message.d && typeof message.d.fen === "string") {
+                    if(message.t && message.t == "move" && message.d.uci) {
+                        if(message.d.castle) {
+                            moves.push(message.d.castle.king[0] + message.d.castle.king[1]);
+                        }
+                        else{
+                            moves.push(message.d.uci);
+                        }
                     }
-                    calculateMove();
+                    if(typeof message.v === "number") {
+                        calculateMove();
+                    }
                 }
             });
             return wrappedWebSocket;
@@ -47,8 +49,8 @@ function interceptWebSocket() {
 }
 
 function calculateMove() {
-    chessEngine.postMessage("position fen " + currentFen);
-    chessEngine.postMessage("go depth 1");
+    chessEngine.postMessage("position startpos moves " + moves.join(' '));
+    chessEngine.postMessage("go depth 6");
 }
 
 function setupChessEngineOnMessage() {

--- a/src/script.user.js
+++ b/src/script.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
-// @name         HyperBullet Lichess Bot
-// @description  Super fast bot
+// @name         Lichess Bot
+// @description  Fully automated lichess bot
 // @author       NuroC, t0gepi
 // @match         *://lichess.org/*
 // @run-at        document-start

--- a/src/script.user.js
+++ b/src/script.user.js
@@ -26,14 +26,17 @@ function interceptWebSocket() {
 
             wrappedWebSocket.addEventListener("message", function (event) {
                 let message = JSON.parse(event.data);
-                console.log(message)
                 if (message.d && typeof message.d.fen === "string") {
                     if(message.t && message.t == "move" && message.d.uci) {
                         if(message.d.castle) {
                             moves.push(message.d.castle.king[0] + message.d.castle.king[1]);
                         }
                         else{
-                            moves.push(message.d.uci);
+                            let move = message.d.uci;
+                            if(message.d.san.includes("=")) {
+                               move += message.d.san.split("=")[1].charAt(0).toLowerCase();
+                            }
+                            moves.push(move);
                         }
                     }
                     if(typeof message.v === "number") {
@@ -50,7 +53,7 @@ function interceptWebSocket() {
 
 function calculateMove() {
     chessEngine.postMessage("position startpos moves " + moves.join(' '));
-    chessEngine.postMessage("go depth 6");
+    chessEngine.postMessage("go depth 13");
 }
 
 function setupChessEngineOnMessage() {


### PR DESCRIPTION
The Old bot was not able to castle due to the fact that lichess's socket protocol does not send the full FEN. 
A "normal" FEN looks like this:
rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
 The last part "KQkq - 0 1" and specifically "KQkq" in that part says that White and Black can both still castle kingside and queenside.
Because this part is missing in Lichess's protocol, the bot always thought that players cant castle. Therefore he played inaccurately and also never castled.

How it is now fixed:
The move calculation is now no longer based on the currentFEN (since that currentFEN is not complete). Move calculation is now based on a list of all moves that have been played so far.
E.g. "position startpos moves e2e4 e7e5 g1f3" and "go depth 8".